### PR TITLE
Fix for issue #8

### DIFF
--- a/knockout.mapping.js
+++ b/knockout.mapping.js
@@ -21,13 +21,31 @@ ko.exportProperty = function (owner, publicName, object) {
 		ignore: []
 	};
 	
+	function extendObject(destination, source) {
+		for (var key in source) {
+			if (source.hasOwnProperty(key) && source[key]) {
+				destination[key] = source[key];
+			}
+		}
+	}
+	function getMergedMapping(mapping1, mapping2) {
+		var mergedMapping = {};
+		extendObject(mergedMapping, mapping1);
+		extendObject(mergedMapping, mapping2);
+
+		return mergedMapping;
+	}
+	
 	ko.mapping.fromJS = function (jsObject, options, target) {
 		if (arguments.length == 0) throw new Error("When calling ko.fromJS, pass the object you want to convert.");
 
 		options = fillOptions(options);
+
 		var result = updateViewModel(target, jsObject, options);
-		result[mappingProperty] = result[mappingProperty] || {};
-		result[mappingProperty] = options;
+
+		// Save any new mapping options in the view model, so that updateFromJS can use them later.
+		result[mappingProperty] = getMergedMapping(result[mappingProperty], options);
+
 		return result;
 	};
 
@@ -123,9 +141,10 @@ ko.exportProperty = function (owner, publicName, object) {
 	function updateViewModel(mappedRootObject, rootObject, options, visitedObjects, parentName, parent) {
 		var isArray = ko.utils.unwrapObservable(rootObject) instanceof Array;
 		
-		// If this object was already mapped previously, take the options from there
+		// If this object was already mapped previously, take the options from there and merge them with our existing ones.
 		if (ko.mapping.isMapped(mappedRootObject)) {
-			options = ko.utils.unwrapObservable(mappedRootObject)[mappingProperty];
+			var previousMapping = ko.utils.unwrapObservable(mappedRootObject)[mappingProperty];
+			options = getMergedMapping(previousMapping, options);
 		}
 		
 		var hasCreateCallback = function () {


### PR DESCRIPTION
Mapping options are merged on subsequent calls to ko.mapping.fromJS, not overwritten. (Fixes issue #8)

Did not add any tests for this, because I'm not entirely sure what would be appropriate---should I check the **ko_mapping** property directly? Should it be more functional, i.e. test that two different mapping options get applied when added in two different fromJS calls?
