### PR TITLE
Cannot set defaultOptions().ignore before mapping

### DIFF
--- a/knockout.mapping.js
+++ b/knockout.mapping.js
@@ -16,7 +16,11 @@ ko.exportProperty = function (owner, publicName, object) {
 	var mappingProperty = "__ko_mapping__";
 	var realKoDependentObservable = ko.dependentObservable;
 
-	var defaultOptions;
+	var _defaultOptions = {
+		include: ["_destroy"],
+		ignore: []
+	};
+	var defaultOptions = _defaultOptions;
 
 	function extendObject(destination, source) {
 		for (var key in source) {
@@ -101,7 +105,7 @@ ko.exportProperty = function (owner, publicName, object) {
 	};
 	
 	ko.mapping.defaultOptions = function() {
-        if (arguments.length > 0) {
+		if (arguments.length > 0) {
 			defaultOptions = arguments[0];
 		} else {
 			return defaultOptions;
@@ -109,10 +113,7 @@ ko.exportProperty = function (owner, publicName, object) {
 	};
 	
 	ko.mapping.resetDefaultOptions = function() {
-		defaultOptions = {
-			include: ["_destroy"],
-			ignore: []
-		};
+		defaultOptions = _defaultOptions;
 	};
 
 	function getType(x) {


### PR DESCRIPTION
When you first call ko.mapping.defaultOptions() it will return
undefined. This prevents you from setting up default ignore options
before you do the mapping.
