### PR TITLE
Ignored properties are not ignored when mapping with a fromJS call

### DIFF
--- a/knockout.mapping.js
+++ b/knockout.mapping.js
@@ -214,7 +214,7 @@ ko.exportProperty = function (owner, publicName, object) {
 
 				// For non-atomic types, visit all properties and update recursively
 				visitPropertiesOrArrayEntries(rootObject, function (indexer) {
-					if ( options.ignore.indexOf(indexer) != -1 ) {
+					if ( options.ignore && options.ignore.indexOf(indexer) != -1 ) {
 						mappedRootObject[indexer] = rootObject[indexer];
 						return;
 					}

--- a/knockout.mapping.js
+++ b/knockout.mapping.js
@@ -214,6 +214,10 @@ ko.exportProperty = function (owner, publicName, object) {
 
 				// For non-atomic types, visit all properties and update recursively
 				visitPropertiesOrArrayEntries(rootObject, function (indexer) {
+					if ( options.ignore.indexOf(indexer) != -1 ) {
+						mappedRootObject[indexer] = rootObject[indexer];
+						return;
+					}
 					var mappedProperty;
 
 					var prevMappedProperty = visitedObjects.get(rootObject[indexer]);

--- a/knockout.mapping.js
+++ b/knockout.mapping.js
@@ -214,10 +214,7 @@ ko.exportProperty = function (owner, publicName, object) {
 
 				// For non-atomic types, visit all properties and update recursively
 				visitPropertiesOrArrayEntries(rootObject, function (indexer) {
-					if ( options.ignore && options.ignore.indexOf(indexer) != -1 ) {
-						mappedRootObject[indexer] = rootObject[indexer];
-						return;
-					}
+					if (options.ignore && ko.utils.arrayIndexOf(options.ignore, indexer) != -1) return;
 					var mappedProperty;
 
 					var prevMappedProperty = visitedObjects.get(rootObject[indexer]);


### PR DESCRIPTION
Hi,

I'm not convinced this is the correct way to fix the problem mentioned as the title of the issue, but it works for me. :-)

I noticed that specify an array of property names to ignore during a fromJS mapping call wasn't working, and this was the first fix I could come up with.  There may be side effects which I have not understood, but the object that comes out the other side of a fromJS call now appears to behave as I expected it to.

Cheers,

Mark.
