### PR TITLE
Fixed Nuget package

### DIFF
--- a/Package.nuspec
+++ b/Package.nuspec
@@ -13,6 +13,6 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="build\output\*.*" target="" /> 
+    <file src="build\output\*.*" target="Content\scripts" /> 
   </files>
 </package>


### PR DESCRIPTION
When installing the knockout.mapping Nuget package (via the Nuget Package Manager Dialog in VS), I receive the error message "External packages cannot depend on packages that target projects."

This appears to be because the nuspec file is not configuring the correct location of where to store the *.js in the target project. 
The nuspec file needs to include a value for the target attribute of the file element.

Something like:

`````` <files>
<file src="build\output\*.*" target="Content\Scripts" /> 
</files>```

Fixed Nuget package so it will correctly deploy to web projects.
``````
