### PR TITLE
Pass parent model as options.parent when mapping array elements

### DIFF
--- a/knockout.mapping.js
+++ b/knockout.mapping.js
@@ -478,7 +478,7 @@ ko.exportProperty = function (owner, publicName, object) {
 				switch (key.status) {
 				case "added":
 					var item = getItemByKey(ko.utils.unwrapObservable(rootObject), key.value, keyCallback);
-					mappedItem = ko.utils.unwrapObservable(updateViewModel(undefined, item, options, parentName, mappedRootObject, fullPropertyName));
+					mappedItem = ko.utils.unwrapObservable(updateViewModel(undefined, item, options, parentName, parent, fullPropertyName));
 
 					var index = ignorableIndexOf(ko.utils.unwrapObservable(rootObject), item, ignoreIndexOf);
 					newContents[index] = mappedItem;
@@ -487,7 +487,7 @@ ko.exportProperty = function (owner, publicName, object) {
 				case "retained":
 					var item = getItemByKey(ko.utils.unwrapObservable(rootObject), key.value, keyCallback);
 					mappedItem = getItemByKey(mappedRootObject, key.value, keyCallback);
-					updateViewModel(mappedItem, item, options, parentName, mappedRootObject, fullPropertyName);
+					updateViewModel(mappedItem, item, options, parentName, parent, fullPropertyName);
 
 					var index = ignorableIndexOf(ko.utils.unwrapObservable(rootObject), item, ignoreIndexOf);
 					newContents[index] = mappedItem;

--- a/spec/mappingBehaviors.js
+++ b/spec/mappingBehaviors.js
@@ -637,17 +637,18 @@ test('ko.mapping.fromJS should send parent along to create callback when creatin
 			{ id: 2 }
 		]
 	};
+
+	var target = {};
 	
 	var numCreated = 0;
 	var result = ko.mapping.fromJS(obj, {
 		"b": {
 			create: function(options) {
-				equal(ko.isObservable(options.parent), true);
-				equal(options.parent() instanceof Array, true);
+				equal(options.parent, target);
 				numCreated++;
 			}
 		}
-	});
+	}, target);
 	
 	equal(numCreated, 2);
 });

--- a/spec/proxyDependentObservableBehaviors.js
+++ b/spec/proxyDependentObservableBehaviors.js
@@ -139,6 +139,8 @@ test('ko.mapping.fromJS should handle dependent observables in arrays', function
 	
 	var dependencyInvocations = 0;
 	
+	var target = {};
+
 	var result = ko.mapping.fromJS(obj, {
 		"items": {
 			create: function(options) {
@@ -146,7 +148,7 @@ test('ko.mapping.fromJS should handle dependent observables in arrays', function
 					id: ko.observable(options.data.id),
 					observeParent: ko.dependentObservable(function() {
 						dependencyInvocations++;
-						return options.parent().length;
+						return options.parent.items().length;
 					})
 				}
 			}


### PR DESCRIPTION
This fixes #33.
