### PR TITLE
Don't wrap dependent observables if already marked as deferEvaluation

### DIFF
--- a/knockout.mapping.js
+++ b/knockout.mapping.js
@@ -231,13 +231,11 @@
 					},
 					deferEvaluation: true
 				});
-				wrapped.__ko_proto__ = realKoDependentObservable;
 				return wrapped;
 			};
 			
 			options.deferEvaluation = true; // will either set for just options, or both read/options.
 			var realDependentObservable = new realKoDependentObservable(read, owner, options);
-			realDependentObservable.__ko_proto__ = realKoDependentObservable;
 
 			if (!realDeferEvaluation) {
 				realDependentObservable = wrap(realDependentObservable);
@@ -246,6 +244,7 @@
 
 			return realDependentObservable;
 		}
+		ko.dependentObservable.fn = realKoDependentObservable.fn;
 		ko.computed = ko.dependentObservable;
 		var result = callback();
 		ko.dependentObservable = localDO;

--- a/knockout.mapping.js
+++ b/knockout.mapping.js
@@ -207,11 +207,11 @@
 		ko.dependentObservable = function (read, owner, options) {
 			options = options || {};
 
-			var realDeferEvaluation = options.deferEvaluation;
-
 			if (read && typeof read == "object") { // mirrors condition in knockout implementation of DO's
 				options = read;
 			}
+
+			var realDeferEvaluation = options.deferEvaluation;
 
 			var isRemoved = false;
 
@@ -231,6 +231,7 @@
 					},
 					deferEvaluation: true
 				});
+				if(DEBUG) wrapped._wrapper = true;
 				return wrapped;
 			};
 			

--- a/spec/proxyDependentObservableBehaviors.js
+++ b/spec/proxyDependentObservableBehaviors.js
@@ -339,6 +339,32 @@ var generateProxyTests = function(useComputed) {
 			equal(i.evaluationCount, 2);
 		});
 	});
+	
+	test('dependentObservable.fn extensions are not missing during mapping', function() {
+		var obj = {
+			x: 1
+		};
+
+		var model = function(data) {
+			var _this = this;
+
+			ko.mapping.fromJS(data, {}, _this);
+			
+			_this.DO = func(_this.x);
+		};
+
+		var mapping = {
+			create: function(options) {
+				return new model(options.data);
+			}
+		};
+		
+		ko.dependentObservable.fn.myExtension = true;
+		
+		var mapped = ko.mapping.fromJS(obj, mapping);
+		
+		equal(mapped.DO.myExtension, true)
+	});
 };
 
 generateProxyTests(false);


### PR DESCRIPTION
As mentioned in Issue #69, the deferEvaluation flag is not always respected.

This is the fix.
