### PR TITLE
programmatically omit a created item from the mapped array 

### DIFF
--- a/knockout.mapping.js
+++ b/knockout.mapping.js
@@ -18,11 +18,8 @@
 	var mappingNesting = 0;
 	var dependentObservables;
 	var visitedObjects;
-<<<<<<< HEAD
 	var recognizedRootProperties = ['create', 'update', 'key', 'arrayChanged'];
-=======
 	var emptyReturn = {};
->>>>>>> added passedOver option to create property function options argument, allowing the returned value to be omitted from the mapped array
 
 	var _defaultOptions = {
 		include: ["_destroy"],
@@ -289,27 +286,19 @@
 
 		var createCallback = function (data) {
 			return withProxyDependentObservable(dependentObservables, function () {
-<<<<<<< HEAD
-				return options[parentName].create({
-					data: data || callbackParams.data,
-					parent: callbackParams.parent
-				});
-=======
 				
 				if (ko.utils.unwrapObservable(parent) instanceof Array) {
-					return getCallback("create")({
+					return options[parentName].create({
 						data: data || callbackParams.data,
 						parent: callbackParams.parent,
-						passOver: emptyReturn
+						skip: emptyReturn
 					});
 				} else {
-					return getCallback("create")({
+					return options[parentName].create({
 						data: data || callbackParams.data,
 						parent: callbackParams.parent,
 					});
-				}
-				
->>>>>>> added passedOver option to create property function options argument, allowing the returned value to be omitted from the mapped array
+				}				
 			});
 		};
 
@@ -523,12 +512,8 @@
 			}
 
 			var newContents = [];
-<<<<<<< HEAD
-			for (i = 0, j = editScript.length; i < j; i++) {
-=======
 			var passedOver = 0;
-			for (var i = 0, j = editScript.length; i < j; i++) {
->>>>>>> added passedOver option to create property function options argument, allowing the returned value to be omitted from the mapped array
+			for (i = 0, j = editScript.length; i < j; i++) {
 				var key = editScript[i];
 				var mappedItem;
 				var fullPropertyName = parentPropertyName + "[" + i + "]";

--- a/knockout.mapping.js
+++ b/knockout.mapping.js
@@ -18,7 +18,11 @@
 	var mappingNesting = 0;
 	var dependentObservables;
 	var visitedObjects;
+<<<<<<< HEAD
 	var recognizedRootProperties = ['create', 'update', 'key', 'arrayChanged'];
+=======
+	var emptyReturn = {};
+>>>>>>> added passedOver option to create property function options argument, allowing the returned value to be omitted from the mapped array
 
 	var _defaultOptions = {
 		include: ["_destroy"],
@@ -285,10 +289,27 @@
 
 		var createCallback = function (data) {
 			return withProxyDependentObservable(dependentObservables, function () {
+<<<<<<< HEAD
 				return options[parentName].create({
 					data: data || callbackParams.data,
 					parent: callbackParams.parent
 				});
+=======
+				
+				if (ko.utils.unwrapObservable(parent) instanceof Array) {
+					return getCallback("create")({
+						data: data || callbackParams.data,
+						parent: callbackParams.parent,
+						passOver: emptyReturn
+					});
+				} else {
+					return getCallback("create")({
+						data: data || callbackParams.data,
+						parent: callbackParams.parent,
+					});
+				}
+				
+>>>>>>> added passedOver option to create property function options argument, allowing the returned value to be omitted from the mapped array
 			});
 		};
 
@@ -407,7 +428,7 @@
 					options.mappedProperties[fullPropertyName] = true;
 				});
 			}
-		} else {
+		} else { //mappedRootObject is an array
 			var changes = [];
 
 			var hasKeyCallback = false;
@@ -502,7 +523,12 @@
 			}
 
 			var newContents = [];
+<<<<<<< HEAD
 			for (i = 0, j = editScript.length; i < j; i++) {
+=======
+			var passedOver = 0;
+			for (var i = 0, j = editScript.length; i < j; i++) {
+>>>>>>> added passedOver option to create property function options argument, allowing the returned value to be omitted from the mapped array
 				var key = editScript[i];
 				var mappedItem;
 				var fullPropertyName = parentPropertyName + "[" + i + "]";
@@ -515,7 +541,15 @@
 					}
 
 					var index = ignorableIndexOf(ko.utils.unwrapObservable(rootObject), item, ignoreIndexOf);
-					newContents[index] = mappedItem;
+					
+					if (mappedItem === emptyReturn) {
+						passedOver++;
+					} else {
+						newContents[index - passedOver] = mappedItem;
+					}
+						
+					
+					
 					ignoreIndexOf[index] = true;
 					break;
 				case "retained":

--- a/spec/proxyDependentObservableBehaviors.js
+++ b/spec/proxyDependentObservableBehaviors.js
@@ -418,6 +418,33 @@ var generateProxyTests = function(useComputed) {
 		equal(mapped.DO2._wrapper, undefined);
 		equal(mapped.DO3._wrapper, true);
 	});
+	
+	test('ko.mapping.updateViewModel should allow for the avoidance of adding an item to its parent observableArray', function() {
+		var obj = {
+			items: [
+				{ id: "a" },
+				{ id: "b" }
+			]
+		}
+		
+		var dependencyInvocations = 0;
+		
+		var result = ko.mapping.fromJS(obj, {
+			"items": {
+				create: function(options) {
+					if (options.data.id == "b")
+						return options.data;
+					else 
+						return options.passOver;
+				}
+			}
+		});
+		
+		
+		equal(result.items().length, 1);
+		equal(result.items()[0].id, "b");
+		
+	});
 };
 
 generateProxyTests(false);

--- a/spec/proxyDependentObservableBehaviors.js
+++ b/spec/proxyDependentObservableBehaviors.js
@@ -435,7 +435,7 @@ var generateProxyTests = function(useComputed) {
 					if (options.data.id == "b")
 						return options.data;
 					else 
-						return options.passOver;
+						return options.skip;
 				}
 			}
 		});
@@ -443,6 +443,36 @@ var generateProxyTests = function(useComputed) {
 		
 		equal(result.items().length, 1);
 		equal(result.items()[0].id, "b");
+		
+	});
+
+	//unit test for updating existing arrays (e.g. first item is retained, second item is skipped and the third item gets added)?
+	test('ko.mapping.updateViewModel skipping an item should retain all other items', function() {
+		var obj = {
+			items: [
+				{ id: "a" },
+				{ id: "b" },
+				{ id: "c" }
+			]
+		}
+		
+		var dependencyInvocations = 0;
+		
+		var result = ko.mapping.fromJS(obj, {
+			"items": {
+				create: function(options) {
+					if (options.data.id == "b")
+						return options.skip;
+					else 
+						return options.data;
+				}
+			}
+		});
+		
+		
+		equal(result.items().length, 2);
+		equal(result.items()[0].id, "a");
+		equal(result.items()[1].id, "c");
 		
 	});
 };


### PR DESCRIPTION
This commit gives the create function the option to omit its result from the mapped array if the parent is an array,
this is my solution for issue #82
