### PR TITLE
Don't update properties on object with update callback

### DIFF
--- a/knockout.mapping.js
+++ b/knockout.mapping.js
@@ -372,6 +372,8 @@
 
 				visitedObjects.save(rootObject, mappedRootObject);
 
+                                if (hasUpdateCallback()) return mappedRootObject;
+                                
 				// For non-atomic types, visit all properties and update recursively
 				visitPropertiesOrArrayEntries(rootObject, function (indexer) {
 					var fullPropertyName = parentPropertyName.length ? parentPropertyName + "." + indexer : indexer;


### PR DESCRIPTION
Probably, you haven't try to update object properties if update callback exists, especially
when some of parents are arrays and you can't set mappings for nested objects
(fullPropertyName has indexes in it, for example `[3].children[5].children[0].id').
