### PR TITLE
Don't recurse into strings in extendObject

### DIFF
--- a/knockout.mapping.js
+++ b/knockout.mapping.js
@@ -43,9 +43,12 @@
 	}
 
 	function extendObject(destination, source) {
+		var destType;
+
 		for (var key in source) {
 			if (source.hasOwnProperty(key) && source[key]) {
-				if (key && destination[key] && !(exports.getType(destination[key]) === "array")) {
+				destType = exports.getType(destination[key]);
+				if (key && destination[key] && destType !== "array" && destType !== "string") {
 					extendObject(destination[key], source[key]);
 				} else {
 					var bothArrays = exports.getType(destination[key]) === "array" && exports.getType(source[key]) === "array";

--- a/spec/issues.js
+++ b/spec/issues.js
@@ -293,3 +293,11 @@ test('Issue #86', function() {
 	model.update({ filters: { a: "a1" }});
 	equal(model.filters.a(), "a1 modified");
 });
+
+test('Issue #107', function () {
+	var model = ko.mapping.fromJS({ foo: 'bar' }, {
+		fiz: 'applesauce'
+	});
+
+	ko.mapping.fromJS({ foo: 'baz' }, model);
+});


### PR DESCRIPTION
Fixes #107.

Another way to settle this would be to specify when we SHOULD recurse, rather than when we shouldn't.
