### PR TITLE
Temporary fix for consecuent ko.mapping.fromJS calls

### DIFF
--- a/knockout.mapping.js
+++ b/knockout.mapping.js
@@ -21,6 +21,17 @@
 	var recognizedRootProperties = ["create", "update", "key", "arrayChanged"];
 	var emptyReturn = {};
 
+
+	// if you need to call two consecuents ko.mapping.fromJS, you shold call
+	// ko.mapping.evaluateDependentObservables() between them.
+	exports.evaluateDependentObservables = function(){
+		while (dependentObservables.length) {
+			var DO = dependentObservables.pop();
+			if (DO) DO();
+		}
+	}
+	
+
 	var _defaultOptions = {
 		include: ["_destroy"],
 		ignore: [],


### PR DESCRIPTION
If you make consecuent calls to ko.mapping.fromJS(), in some cases the computables involved on the viewmodels are not evaluated correctly.
This behaviour is noticeable if you use Validation plugin.

I made this fix, so you can call ko.mapping.evaluateDependentObservables() between each ko.mapping.fromJS(...) call.
# 

ko.mapping.fromJS(....); // mapping the first viewmodel
ko.mapping.evaluateDependentObservables();
ko.mapping.fromJS(....); // mapping the second viewmodel

// now both viewmodels are working correctly, specially those using validation plugin.
# 
