### PR TITLE
remove asynchronous execution of deferred dependent observables

### DIFF
--- a/knockout.mapping.js
+++ b/knockout.mapping.js
@@ -115,15 +115,12 @@
 		}
 
 		// Evaluate any dependent observables that were proxied.
-		// Do this in a timeout to defer execution. Basically, any user code that explicitly looks up the DO will perform the first evaluation. Otherwise,
-		// it will be done by this code.
+		// Do this after the model's observables have been created
 		if (!--mappingNesting) {
-			window.setTimeout(function () {
-				while (dependentObservables.length) {
-					var DO = dependentObservables.pop();
-					if (DO) DO();
-				}
-			}, 0);
+			while (dependentObservables.length) {
+				var DO = dependentObservables.pop();
+				if (DO) DO();
+			}
 		}
 
 		// Save any new mapping options in the view model, so that updateFromJS can use them later.

--- a/spec/proxyDependentObservableBehaviors.js
+++ b/spec/proxyDependentObservableBehaviors.js
@@ -174,37 +174,6 @@ var generateProxyTests = function(useComputed) {
 		equal(result.items()[1].observeParent(), 2);
 	});
 
-	test('nested calls to mapping should not revert proxyDependentObservable multiple times', function() {
-		var vmjs = {
-			"inner1": {
-				"inner2": {
-				}
-			}
-		}
-		var vm = undefined;
-		var mapping = {
-			"inner1": {
-				"create": function(options) {
-					//use the same mapping object to map inner2
-					var that = ko.mapping.fromJS(options.data, mapping);
-					that.DOprop = func(function() {
-						// if the DO is evaluated straight away, this will return undefined
-						return vm;
-					});
-					return that;
-				}
-			},
-			"inner2": {
-				"create": function(options) {
-					var that = ko.mapping.fromJS(options.data);
-					return that;
-				}
-			}
-		};
-		var vm = ko.mapping.fromJS(vmjs, mapping);
-		equal(vm.inner1.DOprop(), vm);
-	});
-
 	test('dependentObservables with a write callback are passed through', function() {
 		var mapped = test.create({ useWriteCallback: true });
 		equal(mapped.a.DO.hasWriteFunction, true);
@@ -280,22 +249,24 @@ var generateProxyTests = function(useComputed) {
 			a: { b: null }
 		};
 
-		var DOsubscribedVal;
+		var DOsubscribedVal ;
 		var mapping = {
 			a: {
 				create: function(options) {
 					var mappedB = ko.mapping.fromJS(options.data, {
 						create: function(options) {
-							var DOval;
+							//In KO writable computed observables have to be backed by an observable
+							//otherwise they won't be notified they need updating. see: http://jsfiddle.net/drdamour/9Pz4m/ 
+							var DOval = ko.observable(undefined);
 							
 							var m = {};
 							m.myValue = ko.observable("myValue");
 							m.DO = func({
 								read: function() {
-									return DOval;
+									return DOval();
 								},
 								write: function(val) {
-									DOval = val;
+									DOval(val);
 								}
 							});
 							m.readOnlyDO = func(function() {
@@ -319,7 +290,7 @@ var generateProxyTests = function(useComputed) {
 		equal(DOsubscribedVal, "bob");
 	});
 	
-	asyncTest('dependentObservable dependencies trigger subscribers', function() {
+	test('dependentObservable dependencies trigger subscribers', function() {
 		var obj = {
 			inner: {
 				dependency: 1
@@ -350,19 +321,13 @@ var generateProxyTests = function(useComputed) {
 		
 		var mapped = ko.mapping.fromJS(obj, mapping);
 		var i = mapped.inner;
-		equal(i.evaluationCount, 0);
-		window.setTimeout(function() {
-			start();
+		equal(i.evaluationCount, 1); //it's evaluated once prior to fromJS returning
+
+		// change the dependency
+		i.dependency(2);
 			
-			// after the timeout, the DO is already evaluated once by the mapping plugin, causing the subscription to update
-			equal(i.evaluationCount, 1);
-			
-			// change the dependency
-			i.dependency(2);
-			
-			// should also have re-evaluated
-			equal(i.evaluationCount, 2);
-		});
+		// should also have re-evaluated
+		equal(i.evaluationCount, 2);
 	});
 	
 	test('dependentObservable.fn extensions are not missing during mapping', function() {

--- a/spec/runner.release.html
+++ b/spec/runner.release.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="UTF-8" />
+	<title>QUnit Test Suite</title>
+	<link rel="stylesheet" href="lib/qunit.css" type="text/css" media="screen">
+	<script type="text/javascript" src="lib/qunit.js"></script>
+	<script type="text/javascript" src="lib/json2.js"></script>
+	<script type="text/javascript" src="http://knockoutjs.com/downloads/knockout-2.2.0.js"></script>
+	<script type="text/javascript" src="../knockout.mapping.js"></script>
+	<script type="text/javascript">
+		var curModuleName;
+		
+		QUnit.moduleStart = function(module) {
+			curModuleName = module.name;
+		};
+	
+		QUnit.moduleDone = function() {
+			curModuleName = "";
+		};
+	
+		var testStart = [];
+		QUnit.testStart = function() {
+			ko.mapping.resetDefaultOptions();
+			testStart[curModuleName] && testStart[curModuleName]();
+		};
+		
+		var testDone = [];
+		QUnit.testDone = function(module) {
+			testDone[curModuleName] && testDone[curModuleName]();
+		};
+		</script>
+    <script type="text/javascript" src="mappingBehaviors.js"></script>
+    <script type="text/javascript" src="proxyDependentObservableBehaviors.js"></script>
+    <script type="text/javascript" src="issues.js"></script>
+</head>
+<body>
+	<h1 id="qunit-header">QUnit Test Suite</h1>
+	<h2 id="qunit-banner"></h2>
+	<div id="qunit-testrunner-toolbar"></div>
+	<h2 id="qunit-userAgent"></h2>
+	<ol id="qunit-tests"></ol>
+	<div id="qunit-fixture">test markup</div>
+</body>
+</html>


### PR DESCRIPTION
this is in regards to https://github.com/SteveSanderson/knockout.mapping/issues/95

I'm not certain why the deffered DO's must be evaluated asynchronously, they should be determined prior to outermost fromJS returning right?  I can assume they must happen after, but none of the unit tests seem to make that necessary.  

I tweaked some unit tests per evaluation at https://github.com/SteveSanderson/knockout.mapping/issues/95#issuecomment-12022149  if you don't agree with those tweaks then this pull wont' make sense.  would love to know the reason behind the async and make a test that enforces that intent instead of some that just verify the behaviour.
