### PR TITLE
Slightly shorter unionArrays

### DIFF
--- a/knockout.mapping.js
+++ b/knockout.mapping.js
@@ -28,18 +28,27 @@
 		observe: []
 	};
 	var defaultOptions = _defaultOptions;
-
-	// Author: KennyTM @ StackOverflow
-	function unionArrays (x, y) {
-		var obj = {};
-		for (var i = x.length - 1; i >= 0; -- i) obj[x[i]] = x[i];
-		for (var i = y.length - 1; i >= 0; -- i) obj[y[i]] = y[i];
-		var res = [];
-
-		for (var k in obj) {
-			res.push(obj[k]);
-		};
-
+	
+	function unionArrays() {
+		var args = arguments,
+		l = args.length,
+		obj = {},
+		res = [],
+		i, j, k;
+		
+		while (l--) {
+			k = args[l];
+			i = k.length;
+			
+			while (i--) {
+				j = k[i];
+				if (!obj[j]) {
+					obj[j] = 1;
+					res.push(j);
+				}
+			}	
+		}
+		
 		return res;
 	}
 


### PR DESCRIPTION
Was fiddling around with unionArrays to see if I could come up with any improvements and this is what I was able to come up with.

Unless I've missed something it should work the same as the original with the following differences:
- Supports an arbitrary # of arrays as input
- Should be a little faster
- Should be a little smaller (242 vs 255 bytes, not including the length of the original attribution)
- Should be a little smaller minified (158 vs 145 bytes using closure compiler)

Performance test:
http://jsperf.com/merge-arrays/4

Quick functionality test at:
http://jsbin.com/ivayet/1/edit
