### PR TITLE
Added ignore callback support

### DIFF
--- a/knockout.mapping.js
+++ b/knockout.mapping.js
@@ -24,6 +24,7 @@
 	var _defaultOptions = {
 		include: ["_destroy"],
 		ignore: [],
+                ignoreCallback: null,
 		copy: [],
 		observe: []
 	};
@@ -162,6 +163,7 @@
 
 		if (arguments.length == 0) throw new Error("When calling ko.mapping.toJS, pass the object you want to convert.");
 		if (exports.getType(defaultOptions.ignore) !== "array") throw new Error("ko.mapping.defaultOptions().ignore should be an array.");
+		if (defaultOptions.ignoreCallback != null && exports.getType(defaultOptions.ignoreCallback) !== "function") throw new Error("ko.mapping.defaultOptions().ignoreCallback should be a function.");
 		if (exports.getType(defaultOptions.include) !== "array") throw new Error("ko.mapping.defaultOptions().include should be an array.");
 		if (exports.getType(defaultOptions.copy) !== "array") throw new Error("ko.mapping.defaultOptions().copy should be an array.");
 
@@ -191,7 +193,8 @@
 		defaultOptions = {
 			include: _defaultOptions.include.slice(0),
 			ignore: _defaultOptions.ignore.slice(0),
-			copy: _defaultOptions.copy.slice(0)
+			copy: _defaultOptions.copy.slice(0),
+			ignoreCallback: _defaultOptions.ignoreCallback
 		};
 	};
 
@@ -224,11 +227,13 @@
 			options.include = mergeArrays(otherOptions.include, options.include);
 			options.copy = mergeArrays(otherOptions.copy, options.copy);
 			options.observe = mergeArrays(otherOptions.observe, options.observe);
+			options.ignoreCallback = options.ignoreCallback ? options.ignoreCallback : otherOptions.ignoreCallback;
 		}
 		options.ignore = mergeArrays(options.ignore, defaultOptions.ignore);
 		options.include = mergeArrays(options.include, defaultOptions.include);
 		options.copy = mergeArrays(options.copy, defaultOptions.copy);
 		options.observe = mergeArrays(options.observe, defaultOptions.observe);
+ 		options.ignoreCallback = options.ignoreCallback ? options.ignoreCallback : defaultOptions.ignoreCallback;
 
 		options.mappedProperties = options.mappedProperties || {};
 		options.copiedProperties = options.copiedProperties || {};
@@ -450,6 +455,9 @@
 						return;
 					}
 
+					if (options.ignoreCallback != null && options.ignoreCallback(fullPropertyName)) {
+		                        	return;
+		                        }
 					if (ko.utils.arrayIndexOf(options.copy, fullPropertyName) != -1) {
 						mappedRootObject[indexer] = rootObject[indexer];
 						return;
@@ -733,6 +741,7 @@
 		visitPropertiesOrArrayEntries(unwrappedRootObject, function (indexer) {
 			if (options.ignore && ko.utils.arrayIndexOf(options.ignore, indexer) != -1) return;
 
+			if (options.ignoreCallback != null && options.ignoreCallback(indexer)) return;
 			var propertyValue = unwrappedRootObject[indexer];
 			options.parentName = getPropertyName(parentName, unwrappedRootObject, indexer);
 


### PR DESCRIPTION
Hi Steve,

I am loving knockout so far and find the knock mapping plug-in very useful.
But I missed a generic way to ignore properties to map (currently, you can ignore them by name only).

Hence I decided to add an optional ignore callback to the option - allowing  to ignore properties based on patterns (e.g. some naming convention) additionally to the ignore array.
I am using this as a global configuration and all my models (if they follow the naming convention) work with that just fine.

I hope that is a useful addition to have and wanted to contribute this (this is the first time I do such a thing, so apologies for any issues I am causing).

If my approach is not acceptable though, it would be nice to see some similar approach (probably to the other configuration types as well) in the future.

Thanks

Michael
