### PR TITLE
Only get types once in mergeArrays

### DIFF
--- a/knockout.mapping.js
+++ b/knockout.mapping.js
@@ -237,15 +237,18 @@
 	}
 
 	function mergeArrays(a, b) {
-		var typeA = exports.getType(a);
-		if (typeA !== "array") {
-			if (typeA === "undefined") a = [];
-			else a = [a];
+		if (a === undefined) {
+			a = [];
 		}
-		var typeB = exports.getType(b);
-		if (typeB !== "array") {
-			if (typeB === "undefined") b = [];
-			else b = [b];
+		else if (exports.getType(a) !== "array") {
+			a = [a];
+		}
+		
+		if (b === undefined) {
+			b = [];
+		}
+		else if (exports.getType(b) !== "array") {
+			b = [b];
 		}
 
 		return ko.utils.arrayGetDistinctValues(a.concat(b));

--- a/knockout.mapping.js
+++ b/knockout.mapping.js
@@ -237,12 +237,14 @@
 	}
 
 	function mergeArrays(a, b) {
-		if (exports.getType(a) !== "array") {
-			if (exports.getType(a) === "undefined") a = [];
+		var typeA = exports.getType(a);
+		if (typeA !== "array") {
+			if (typeA === "undefined") a = [];
 			else a = [a];
 		}
-		if (exports.getType(b) !== "array") {
-			if (exports.getType(b) === "undefined") b = [];
+		var typeB = exports.getType(b);
+		if (typeB !== "array") {
+			if (typeB === "undefined") b = [];
 			else b = [b];
 		}
 


### PR DESCRIPTION
Make a max of 2 calls to exports.getType instead of 4 calls.
Should be slightly faster and a little smaller when minified.
