### PR TITLE
Put null check first in canHaveProperties

### DIFF
--- a/knockout.mapping.js
+++ b/knockout.mapping.js
@@ -690,8 +690,11 @@
 	};
 
 	function canHaveProperties(object) {
+		if (object === null) {
+			return false;
+		}
 		var type = exports.getType(object);
-		return ((type === "object") || (type === "array")) && (object !== null);
+		return (type === "object") || (type === "array");
 	}
 
 	// Based on the parentName, this creates a fully classified name of a property


### PR DESCRIPTION
Put the null check first so that we skip the call to exports.getType and the 2 string comparisons if the object is null.
