### PR TITLE
Use intermediate vars to decrease minified size

### DIFF
--- a/knockout.mapping.js
+++ b/knockout.mapping.js
@@ -743,11 +743,15 @@
 				if (ko.utils.arrayIndexOf(options.include, indexer) === -1) {
 					// The mapped properties object contains all the properties that were part of the original object.
 					// If a property does not exist, and it is not because it is part of an array (e.g. "myProp[3]"), then it should not be unmapped.
-				    if (unwrappedRootObject[mappingProperty]
-				        && unwrappedRootObject[mappingProperty].mappedProperties && !unwrappedRootObject[mappingProperty].mappedProperties[indexer]
-				        && unwrappedRootObject[mappingProperty].copiedProperties && !unwrappedRootObject[mappingProperty].copiedProperties[indexer]
-				        && !(exports.getType(unwrappedRootObject) === "array")) {
-						return;
+					var unwrappedRootMappingProperty = unwrappedRootObject[mappingProperty];
+					if (unwrappedRootMappingProperty) {
+						var mappedProperties = unwrappedRootMappingProperty.mappedProperties;
+						if (mappedProperties && !mappedProperties[indexer]) {
+							var copiedProperties = unwrappedRootMappingProperty.copiedProperties;
+							if (copiedProperties && !copiedProperties[indexer] && !(exports.getType(unwrappedRootObject) === "array")) {
+								return;
+							}
+						}
 					}
 				}
 			}

--- a/knockout.mapping.js
+++ b/knockout.mapping.js
@@ -748,7 +748,7 @@
 						var mappedProperties = unwrappedRootMappingProperty.mappedProperties;
 						if (mappedProperties && !mappedProperties[indexer]) {
 							var copiedProperties = unwrappedRootMappingProperty.copiedProperties;
-							if (copiedProperties && !copiedProperties[indexer] && !(exports.getType(unwrappedRootObject) === "array")) {
+							if (copiedProperties && !copiedProperties[indexer] && (exports.getType(unwrappedRootObject) !== "array")) {
 								return;
 							}
 						}


### PR DESCRIPTION
Closure compiler applied to exports.visitModel shows a decrease from 1005 bytes down to 930 bytes.
