### PR TITLE
Use hasOwnProperty to check for bucket existence

### DIFF
--- a/knockout.mapping.js
+++ b/knockout.mapping.js
@@ -799,7 +799,7 @@
 			}
 
 			var bucket = buckets[bucketKey];
-			if (bucket === undefined) {
+			if (!buckets.hasOwnProperty(bucketKey)) {
 				bucket = new simpleObjectLookup();
 				buckets[bucketKey] = bucket;
 			}

--- a/spec/issues.js
+++ b/spec/issues.js
@@ -314,3 +314,10 @@ test('Issue #107', function () {
 
 	equal(model.foo(), "baz");
 });
+
+//https://github.com/SteveSanderson/knockout.mapping/issues/124
+test('Issue #124', function () {
+	var model = ko.mapping.fromJS({ foo: 'constructor' });
+
+	equal(model.foo(), 'constructor');
+});


### PR DESCRIPTION
If a mapped observable has a value that is a property of `Object.prototype`,
`findBucket` returns that property's value instead of a `simpleObjectLookup`
instance.

Fix #124
