### PR TITLE
preserve the oa instance when it appears in data

### DIFF
--- a/knockout.mapping.js
+++ b/knockout.mapping.js
@@ -503,7 +503,7 @@
 
 			if (!ko.isObservable(mappedRootObject)) {
 				// When creating the new observable array, also add a bunch of utility functions that take the 'key' of the array items into account.
-				mappedRootObject = ko.observableArray([]);
+				mappedRootObject = exports.getType(rootObject) === "function" ? rootObject : ko.observableArray([]);
 
 				mappedRootObject.mappedRemove = function (valueOrPredicate) {
 					var predicate = typeof valueOrPredicate == "function" ? valueOrPredicate : function (value) {

--- a/spec/issues.js
+++ b/spec/issues.js
@@ -314,3 +314,14 @@ test('Issue #107', function () {
 
 	equal(model.foo(), "baz");
 });
+
+//https://github.com/SteveSanderson/knockout.mapping/issues/177
+test('Issue #177', function () {
+	var model = ko.mapping.fromJS({});
+	var o = ko.observable();
+	var oa = ko.observableArray();
+
+	ko.mapping.fromJS({o: o, oa: oa}, model);
+	equal(model.o, o);
+	equal(model.oa, oa);
+});


### PR DESCRIPTION
this may be easiest to illustrate with code:

``` js
var o = ko.observable()
var oa = ko.observableArray()
var model = {};

ko.mapping.fromJS({o: o, oa: oa}, model);

equal(model.o, o); // this is currently true
equal(model.oa, oa) // this isn't true, but is fixed with this commit
```

the problem is that using ko.mapping, if you've got an existing OA,
there's no way to update a viewmodel with the existing OA, a new one is
always created.

this pull request provides a way to update viewmodels to reference
pre-existing observable arrays.
