### PR TITLE
Add package definition for NPM and bower registries

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,29 @@
+{
+  "name": "knockout.mapping",
+  "version": "2.4.1",
+  "authors": [
+	"Steve Sanderson"
+  ],
+  "description": "Object mapping plugin for KnockoutJS",
+  "main": "knockout.mapping.js",
+  "keywords": [
+    "knockout",
+    "knockoutjs",
+    "mapping",
+    "plugin",
+    "object"
+  ],
+  "license": "MIT",
+  "homepage": "https://github.com/SteveSanderson/knockout.mapping",
+  "ignore": [
+    "**/.*",
+    "build/tools",
+    "build/build-linux",
+    "build/version-header.js",
+    "Package.nuspec",
+    "spec"
+  ],
+  "dependencies": {
+    "knockout": ">=2.0.0"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+﻿{
+  "name": "knockout.mapping",
+  "version": "2.4.1",
+  "description": "Object mapping plugin for KnockoutJS",
+  "main": "knockout.mapping.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/SteveSanderson/knockout.mapping.git"
+  },
+  "keywords": [
+    "**/.*",
+    "build/tools",
+    "build/build-linux",
+    "build/version-header.js",
+    "Package.nuspec",
+    "spec"
+  ],
+  "devDependencies": {
+  },
+  "author": "Steven Sanderson",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/SteveSanderson/knockout.mapping/issues"
+  }
+}


### PR DESCRIPTION
Hi,

I created a package definition for node and bower registries. I do not publish in order to keep things clear.
Also, if you want, SPATools is an account which assemble many tools to help creating Single Page Application.

We would love to maintain the package if you can't continue du to time. We could add top maintainers as project administrators and let the library evolve.

What do you think ?
