### PR TITLE
Fix objects observability

### DIFF
--- a/knockout.mapping.js
+++ b/knockout.mapping.js
@@ -115,6 +115,7 @@
 			options = fillOptions(options);
 
 			var result = updateViewModel(target, jsObject, options);
+		    result = ko.utils.unwrapObservable(result);
 			if (target) {
 				result = target;
 			}
@@ -365,9 +366,13 @@
 			return options[parentName].update(params);
 		}
 
+        var ensureObservable = function(value) {
+            return ko.isObservable(value) ? value : ko.observable(value);
+        }
+
 		var alreadyMapped = visitedObjects.get(rootObject);
 		if (alreadyMapped) {
-			return alreadyMapped;
+			return ensureObservable(alreadyMapped);
 		}
 
 		parentName = parentName || "";
@@ -393,11 +398,11 @@
 						if (hasUpdateCallback()) {
 							var valueToWrite = updateCallback(mappedRootObject);
 							mappedRootObject(valueToWrite);
-							return valueToWrite;
+							return mappedRootObject;
 						} else {
 							var valueToWrite = ko.utils.unwrapObservable(rootObject);
 							mappedRootObject(valueToWrite);
-							return valueToWrite;
+							return mappedRootObject;
 						}
 					} else {
 						var hasCreateOrUpdateCallback = hasCreateCallback() || hasUpdateCallback();
@@ -488,6 +493,8 @@
 
 					options.mappedProperties[fullPropertyName] = true;
 				});
+
+			    mappedRootObject = ensureObservable(mappedRootObject);
 			}
 		} else { //mappedRootObject is an array
 			var changes = [];


### PR DESCRIPTION
Sometimes fields of type 'object' are mapped incorrectly. I've made an assumption that updateViewModel should always return observable object and fixed the implementation in order to enforce this. It looks like this fixed my issues.
